### PR TITLE
chore: add GitHub issue and pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: "[BUG] "
+labels: bug
+---
+
+## Description
+
+A clear description of the bug.
+
+## Steps to Reproduce
+
+1.
+2.
+3.
+
+## Expected Behavior
+
+What you expected to happen.
+
+## Actual Behavior
+
+What actually happened.
+
+## Environment
+
+- Nephos version:
+- Angular version:
+- Browser:
+
+## Additional Context
+
+Screenshots, error logs, or any other relevant information.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature Request
+about: Suggest a new feature or enhancement
+title: "[FEATURE] "
+labels: enhancement
+---
+
+## Problem
+
+What problem does this feature solve?
+
+## Proposed Solution
+
+Describe the solution you'd like.
+
+## Alternatives Considered
+
+Any alternative approaches you've thought about.
+
+## Additional Context
+
+Any other context or references.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+## Summary
+
+Brief description of what this PR does.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+- [ ] Refactor / code quality improvement
+
+## Checklist
+
+- [ ] Code follows the project conventions (standalone components, signals, strict mode)
+- [ ] Component has a corresponding `.spec.ts` file
+- [ ] `npm test` passes for the affected library
+- [ ] Self-review completed
+- [ ] Commit messages follow [conventional commits](https://www.conventionalcommits.org/)
+
+## Related Issues
+
+Closes #(issue)


### PR DESCRIPTION
## Summary

Adds standardized issue and pull request templates.

## Changes

- **`.github/ISSUE_TEMPLATE/bug_report.md`** — structured bug report with reproduction steps and environment info
- **`.github/ISSUE_TEMPLATE/feature_request.md`** — feature request with problem statement and proposed solution
- **`.github/PULL_REQUEST_TEMPLATE.md`** — PR checklist aligned with project conventions (standalone components, signals, strict mode, spec files)

## Why

The repository currently has no issue or PR templates. Standardized templates help maintain quality and guide contributors as the project grows.